### PR TITLE
fix: open links in new window

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -52,7 +52,7 @@
 				/>
 				<iframe
 					ref="previewFrame"
-					srcdoc="<link rel='stylesheet' href='https://cdnjs.cloudflare.com/ajax/libs/github-markdown-css/4.0.0/github-markdown.min.css'><link rel='stylesheet' href='https://unpkg.com/highlight.js@10.4.1/styles/github-gist.css'><style>.markdown-body{ padding: 32px }</style><div class='markdown-body'></div>"
+					srcdoc="<link rel='stylesheet' href='https://cdnjs.cloudflare.com/ajax/libs/github-markdown-css/4.0.0/github-markdown.min.css'><link rel='stylesheet' href='https://unpkg.com/highlight.js@10.4.1/styles/github-gist.css'><base target='_blank'><style>.markdown-body{ padding: 32px }</style><div class='markdown-body'></div>"
 					@load.once="renderMarkdown"
 				/>
 			</div>


### PR DESCRIPTION
Fix for https://github.com/privatenumber/litemark/issues/4 

Originally I used marked's inline-level renderer to force all links to have a target="_blank", however I tested it out by using the readme.md of litemark itself and found that won't help if users inline their own html inside the markdown. I could have done something a bit hacky like listen to all anchor clicks and take over, but found the nifty `<base target="_blank">` trick that provides that default over the whole iframe 🎉 